### PR TITLE
feat: Add visual flash feedback to mapping cards on capture trigger 

### DIFF
--- a/main/MIDI Mapper/src/midi_engine.cpp
+++ b/main/MIDI Mapper/src/midi_engine.cpp
@@ -82,7 +82,8 @@ void ProcessChord(const std::vector<int>& chord) {
 
     // 1. Try to find a specific chord mapping
     if (sortedChord.size() > 1) {
-        for (const auto& m : g_mappings) {
+        for (size_t i = 0; i < g_mappings.size(); ++i) {
+            const auto& m = g_mappings[i];
             if (m.midi_type != 2) continue;
 
             // Context Stack Filtering
@@ -102,6 +103,7 @@ void ProcessChord(const std::vector<int>& chord) {
 
             if (targetChord == sortedChord) {
                 SimulateKeyCombo(m.key_vk, m.modifiers);
+                PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
                 SendLog("Match found! Triggering VK " + std::to_string(m.key_vk));
                 found = true;
                 break;
@@ -215,7 +217,8 @@ void ProcessMIDIEvent(int type, int number, int velocity) {
     std::string cachedApp = WideToUtf8(g_currentApp);
 
     std::lock_guard<std::recursive_mutex> lock(g_mappingsMutex);
-    for (const auto& m : g_mappings) {
+    for (size_t i = 0; i < g_mappings.size(); ++i) {
+        const auto& m = g_mappings[i];
         if (!m.enabled) continue; // Skip disabled mappings
 
         // Context filtering (using pre-computed strings)
@@ -231,6 +234,7 @@ void ProcessMIDIEvent(int type, int number, int velocity) {
             if (m.midi_type == 0 && isNoteOn && number == m.midi_num) {
                 if (m.profile_switch < (int)g_profileSlots.size()) {
                     PostMessage(g_hwndMain, WM_USER + 100, m.profile_switch, 0);
+                    PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
                 }
             }
             continue;
@@ -246,6 +250,7 @@ void ProcessMIDIEvent(int type, int number, int velocity) {
                     if (m.vel_zone == 2 && velocity < 64) continue;
                 }
                 SendKeyInput(m.key_vk, true, m.modifiers);
+                PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
                 if (g_verboseLogging) SendLog("Note " + std::to_string(number) + " -> Key Down: " + std::to_string(m.key_vk), "mapping");
             }
             else if (isNoteOff) {
@@ -266,19 +271,21 @@ void ProcessMIDIEvent(int type, int number, int velocity) {
             case 0: // Keypress (Now Momentary by default for games)
                 if (ccCrossedUp) {
                     SendKeyInput(m.key_vk, true, m.modifiers);
+                    PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
                     if (g_verboseLogging) SendLog("CC " + std::to_string(number) + " -> Key Down: " + std::to_string(m.key_vk), "mapping");
                 } else if (ccCrossedDown) {
                     SendKeyInput(m.key_vk, false, m.modifiers);
                     if (g_verboseLogging) SendLog("CC " + std::to_string(number) + " -> Key Up: " + std::to_string(m.key_vk), "mapping");
                 }
                 break;
-            case 1: SimulateMouseMove((velocity - 64) * 2, 0); break;
-            case 2: SimulateMouseMove(0, (velocity - 64) * 2); break;
-            case 3: SimulateScroll((velocity - 64) * 20); break;
+            case 1: SimulateMouseMove((velocity - 64) * 2, 0); PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} }); break;
+            case 2: SimulateMouseMove(0, (velocity - 64) * 2); PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} }); break;
+            case 3: SimulateScroll((velocity - 64) * 20); PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} }); break;
             case 4: // Hold Key (Dedicated toggle behavior or held state)
                 if (ccCrossedUp && !g_ccHoldActive[m.midi_num]) {
                     SendKeyInput(m.key_vk, true);
                     g_ccHoldActive[m.midi_num] = true;
+                    PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
                 }
                 else if (ccCrossedDown && g_ccHoldActive[m.midi_num]) {
                     SendKeyInput(m.key_vk, false);
@@ -291,13 +298,18 @@ void ProcessMIDIEvent(int type, int number, int velocity) {
         // Macros, AI, HUD
         if (m.midi_type == 4 && isNoteOn && number == m.midi_num && m.gesture_id == 0) {
             SimulateText(m.macro_text);
+            PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
         }
         if (m.midi_type == 5 && isNoteOn && number == m.midi_num && m.gesture_id == 0) {
             PostToWebView({ {"type", "run_ai"}, {"prompt", m.ai_prompt} });
+            PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
             SendLog("AI Prompt sent: " + m.ai_prompt);
         }
         if (m.midi_type == 3 && number == m.midi_num) {
-            if (isNoteOn) PostToWebView({ {"type", "hud"}, {"active", true}, {"title", WideToUtf8(GetModifierString(m.modifiers) + GetKeyName(m.key_vk))} });
+            if (isNoteOn) {
+                PostToWebView({ {"type", "hud"}, {"active", true}, {"title", WideToUtf8(GetModifierString(m.modifiers) + GetKeyName(m.key_vk))} });
+                PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
+            }
             else if (isNoteOff) PostToWebView({ {"type", "hud"}, {"active", false} });
         }
     }
@@ -307,7 +319,8 @@ void ResolveGesture(int midi_num, int gesture_id) {
     std::string cachedTitle = WideToUtf8(g_currentWindowTitle);
     std::string cachedApp = WideToUtf8(g_currentApp);
     std::lock_guard<std::recursive_mutex> lock(g_mappingsMutex);
-    for (const auto& m : g_mappings) {
+    for (size_t i = 0; i < g_mappings.size(); ++i) {
+        const auto& m = g_mappings[i];
         if (!m.enabled) continue;
         if (m.midi_num != midi_num) continue;
         
@@ -323,9 +336,18 @@ void ResolveGesture(int midi_num, int gesture_id) {
         }
 
         // Execute (Simplified trigger for gesture demo)
-        if (m.midi_type == 0) SimulateKeyCombo(m.key_vk, m.modifiers);
-        else if (m.midi_type == 4) SimulateText(m.macro_text);
-        else if (m.midi_type == 5) PostToWebView({ {"type", "run_ai"}, {"prompt", m.ai_prompt} });
+        if (m.midi_type == 0) {
+            SimulateKeyCombo(m.key_vk, m.modifiers);
+            PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
+        }
+        else if (m.midi_type == 4) {
+            SimulateText(m.macro_text);
+            PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
+        }
+        else if (m.midi_type == 5) {
+            PostToWebView({ {"type", "run_ai"}, {"prompt", m.ai_prompt} });
+            PostToWebView({ {"type", "mapping_triggered"}, {"index", (int)i} });
+        }
     }
 }
 

--- a/main/MIDI Mapper/src/ui/app.js
+++ b/main/MIDI Mapper/src/ui/app.js
@@ -61,11 +61,25 @@ if (window.chrome?.webview) {
             case 'log': addLog(msg.text, msg.category); break;
             case 'run_ai': handleAiRequest(msg.prompt); break;
             case 'ports': updatePorts(msg.ports, msg.selected); break;
+            case 'mapping_triggered': flashMappingCard(msg.index); break;
             case 'config': syncConfig(msg.config); break;
             case 'toast': showToast(msg.text, msg.level || 'info'); break;
             case 'piano_decay': handlePianoDecay(msg.keys); break;
         }
     });
+}
+
+function flashMappingCard(index) {
+    const card = document.getElementById(`mapping-card-${index}`);
+    if (card) {
+        // Reset animation by removing and re-adding class
+        card.classList.remove('flash-trigger');
+        void card.offsetWidth; // trigger reflow
+        card.classList.add('flash-trigger');
+        setTimeout(() => {
+            card.classList.remove('flash-trigger');
+        }, 300);
+    }
 }
 
 // --- UI Logic ---
@@ -157,6 +171,7 @@ function updateMappings(list) {
 
         const card = document.createElement('div');
         card.className = 'mapping-card';
+        card.id = `mapping-card-${i}`;
         if (m.enabled === false) card.style.opacity = '0.4';
 
         // Color-coded left border by mapping type

--- a/main/MIDI Mapper/src/ui/design_system.css
+++ b/main/MIDI Mapper/src/ui/design_system.css
@@ -227,6 +227,17 @@ body {
   box-shadow: var(--shadow-md);
 }
 
+.mapping-card.flash-trigger {
+  animation: mappingTriggerFlash 0.3s ease-out;
+  border-color: var(--system-green) !important;
+}
+
+@keyframes mappingTriggerFlash {
+  0% { transform: scale(1); box-shadow: 0 0 0px rgba(40, 200, 64, 0); }
+  10% { transform: scale(1.02); box-shadow: 0 0 15px rgba(40, 200, 64, 0.6); border-color: var(--system-green); }
+  100% { transform: scale(1); box-shadow: 0 0 0px rgba(40, 200, 64, 0); }
+}
+
 .badge {
   font-size: 10px;
   font-weight: 700;


### PR DESCRIPTION
Fixes #16   

Description When a user presses a MIDI key that matches one of their saved mappings, the UI didn't previously provide any visual feedback that the mapping card was recognized and executed. This PR adds a brief flash animation directly to the recognized mapping card in real-time.


Changes:

Changes:
- Backend (midi_engine.cpp):Updated ProcessChord, ProcessMIDIEvent, and ResolveGesture to track loops by index. Added PostToWebView({ {"type", "mapping_triggered"}, {"index", i} }) immediately upon a successful action trigger (Keypress, Macro, AI).
- Frontend (app.js): Modified mapping rendering logic to apply explicit IDs to generated mapping cards (mapping-card-{index}). 
- Frontend (app.js): Added a listener for the mapping_triggered message that uses DOM reflow to append and remove a temporary animation class over ~300ms.
- Frontend (design_system.css): Implemented .flash-trigger class using @keyframes to apply a real-time glowing green border (var(--system-green)) and brief 1.02x scale transformation to the playing card.

Acceptance Criteria Met:
- [x] Card briefly flashes/scales for ~300ms when triggered.
- [x] Flash happens in real-time as the MIDI event successfully matches and executes.
- [x] UI receives the trigger event directly from the backend to guarantee accuracy.